### PR TITLE
Enhance remote wishlist image loading and card handling features

### DIFF
--- a/src/MtgCollectionTracker.ApiClient/Generated/MtgCollectionTrackerApiClient.g.cs
+++ b/src/MtgCollectionTracker.ApiClient/Generated/MtgCollectionTrackerApiClient.g.cs
@@ -306,6 +306,26 @@ namespace MtgCollectionTracker.ApiClient.Generated
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>OK</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task Large3Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task Small3Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task Large4Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task Small4Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<bool> IsEmptyAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -4545,6 +4565,286 @@ namespace MtgCollectionTracker.ApiClient.Generated
                 
                     // Operation Path: "api/images/sku/{id}/back/small"
                     urlBuilder_.Append("api/images/sku/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/back/small");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task Large3Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "api/images/wishlist/{id}/front/large"
+                    urlBuilder_.Append("api/images/wishlist/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/front/large");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task Small3Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "api/images/wishlist/{id}/front/small"
+                    urlBuilder_.Append("api/images/wishlist/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/front/small");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task Large4Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "api/images/wishlist/{id}/back/large"
+                    urlBuilder_.Append("api/images/wishlist/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/back/large");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            return;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>OK</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task Small4Async(int id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                
+                    // Operation Path: "api/images/wishlist/{id}/back/small"
+                    urlBuilder_.Append("api/images/wishlist/");
                     urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/back/small");
 

--- a/src/MtgCollectionTracker.ApiClient/MtgCollectionTracker.Server.json
+++ b/src/MtgCollectionTracker.ApiClient/MtgCollectionTracker.Server.json
@@ -1832,6 +1832,102 @@
         }
       }
     },
+    "/api/images/wishlist/{id}/front/large": {
+      "get": {
+        "tags": [
+          "MtgCollectionTracker.Server"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/images/wishlist/{id}/front/small": {
+      "get": {
+        "tags": [
+          "MtgCollectionTracker.Server"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/images/wishlist/{id}/back/large": {
+      "get": {
+        "tags": [
+          "MtgCollectionTracker.Server"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/images/wishlist/{id}/back/small": {
+      "get": {
+        "tags": [
+          "MtgCollectionTracker.Server"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)$",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/identifiers/isEmpty": {
       "get": {
         "tags": [

--- a/src/MtgCollectionTracker.ApiClient/RemoteCollectionTrackingService.cs
+++ b/src/MtgCollectionTracker.ApiClient/RemoteCollectionTrackingService.cs
@@ -423,6 +423,18 @@ public class RemoteCollectionTrackingService : ICollectionTrackingService
     public async ValueTask<Stream?> GetSmallBackFaceImageAsync(Guid cardSkuId, CancellationToken cancel)
         => await GetImageAsync($"/api/images/sku/{cardSkuId}/back/small", cancel);
 
+    public async ValueTask<Stream?> GetLargeFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+        => await GetImageAsync($"/api/images/wishlist/{wishlistItemId}/front/large", cancel);
+
+    public async ValueTask<Stream?> GetSmallFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+        => await GetImageAsync($"/api/images/wishlist/{wishlistItemId}/front/small", cancel);
+
+    public async ValueTask<Stream?> GetLargeBackFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+        => await GetImageAsync($"/api/images/wishlist/{wishlistItemId}/back/large", cancel);
+
+    public async ValueTask<Stream?> GetSmallBackFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+        => await GetImageAsync($"/api/images/wishlist/{wishlistItemId}/back/small", cancel);
+
     // ── Scryfall identifiers ──────────────────────────────────────────────────
 
     public async ValueTask<bool> IsScryfallIdMappingEmptyAsync(CancellationToken cancel)

--- a/src/MtgCollectionTracker.Core/Services/CollectionTrackingService.cs
+++ b/src/MtgCollectionTracker.Core/Services/CollectionTrackingService.cs
@@ -1870,6 +1870,15 @@ public class CollectionTrackingService : ICollectionTrackingService
             .FirstOrDefaultAsync();
     }
 
+    private async ValueTask<string?> GetScryfallIdForWishlistItemAsync(int wishlistItemId)
+    {
+        using var db = _db.Invoke();
+        return await db.Value.WishlistItems
+            .Where(w => w.Id == wishlistItemId)
+            .Select(w => w.ScryfallId)
+            .FirstOrDefaultAsync();
+    }
+
     public async ValueTask<Stream?> GetLargeFrontFaceImageAsync(Guid cardSkuId, CancellationToken cancel)
     {
         var scryfallId = await GetScryfallIdForSkuAsync(cardSkuId);
@@ -1891,6 +1900,30 @@ public class CollectionTrackingService : ICollectionTrackingService
     public async ValueTask<Stream?> GetSmallBackFaceImageAsync(Guid cardSkuId, CancellationToken cancel)
     {
         var scryfallId = await GetScryfallIdForSkuAsync(cardSkuId);
+        return scryfallId is null ? null : await _cache.GetSmallBackFaceImageAsync(scryfallId);
+    }
+
+    public async ValueTask<Stream?> GetLargeFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        var scryfallId = await GetScryfallIdForWishlistItemAsync(wishlistItemId);
+        return scryfallId is null ? null : await _cache.GetLargeFrontFaceImageAsync(scryfallId);
+    }
+
+    public async ValueTask<Stream?> GetLargeBackFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        var scryfallId = await GetScryfallIdForWishlistItemAsync(wishlistItemId);
+        return scryfallId is null ? null : await _cache.GetLargeBackFaceImageAsync(scryfallId);
+    }
+
+    public async ValueTask<Stream?> GetSmallFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        var scryfallId = await GetScryfallIdForWishlistItemAsync(wishlistItemId);
+        return scryfallId is null ? null : await _cache.GetSmallFrontFaceImageAsync(scryfallId);
+    }
+
+    public async ValueTask<Stream?> GetSmallBackFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        var scryfallId = await GetScryfallIdForWishlistItemAsync(wishlistItemId);
         return scryfallId is null ? null : await _cache.GetSmallBackFaceImageAsync(scryfallId);
     }
 

--- a/src/MtgCollectionTracker.Core/Services/ICollectionTrackingService.cs
+++ b/src/MtgCollectionTracker.Core/Services/ICollectionTrackingService.cs
@@ -115,6 +115,18 @@ namespace MtgCollectionTracker.Core.Services
 
         /// <summary>Fetches the small back-face image for the card SKU with the given id.</summary>
         ValueTask<Stream?> GetSmallBackFaceImageAsync(Guid cardSkuId, CancellationToken cancel);
+
+        /// <summary>Fetches the large front-face image for the wishlist item with the given id.</summary>
+        ValueTask<Stream?> GetLargeFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel);
+
+        /// <summary>Fetches the large back-face image for the wishlist item with the given id.</summary>
+        ValueTask<Stream?> GetLargeBackFaceImageAsync(int wishlistItemId, CancellationToken cancel);
+
+        /// <summary>Fetches the small front-face image for the wishlist item with the given id.</summary>
+        ValueTask<Stream?> GetSmallFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel);
+
+        /// <summary>Fetches the small back-face image for the wishlist item with the given id.</summary>
+        ValueTask<Stream?> GetSmallBackFaceImageAsync(int wishlistItemId, CancellationToken cancel);
         ValueTask<IReadOnlyList<string>> GetTagsAsync(CancellationToken cancel);
         ValueTask<ApplyTagsResult> ApplyTagsAsync(IEnumerable<string> tags, CancellationToken cancel);
         ValueTask AddMissingMetadataAsync(UpdateCardMetadataProgressCallback callback, IScryfallApiClient scryfallApiClient, CancellationToken cancel);

--- a/src/MtgCollectionTracker.Server/Program.cs
+++ b/src/MtgCollectionTracker.Server/Program.cs
@@ -236,7 +236,13 @@ app.MapPut("/api/cards/{id:guid}", async (
     IScryfallApiClient scryfallApi,
     CancellationToken cancel) =>
 {
-    model.Ids = new[] { id };
+    // Preserve any batched ids supplied in the body for remote callers. The route id remains a
+    // fallback for older single-item clients that do not populate model.Ids.
+    if (!model.Ids.Any())
+    {
+        model.Ids = new[] { id };
+    }
+
     var result = await svc.UpdateCardSkuAsync(model, scryfallApi, cancel);
     return TypedResults.Ok(result);
 });

--- a/src/MtgCollectionTracker.Server/Program.cs
+++ b/src/MtgCollectionTracker.Server/Program.cs
@@ -631,6 +631,44 @@ app.MapGet("/api/images/sku/{id:guid}/back/small", async (
     return stream is null ? Results.NotFound() : Results.Stream(stream, "image/jpeg");
 });
 
+// ── Wishlist item images by wishlist item ID ───────────────────────────────────
+
+app.MapGet("/api/images/wishlist/{id:int}/front/large", async (
+    int id,
+    ICollectionTrackingService svc,
+    CancellationToken cancel) =>
+{
+    var stream = await svc.GetLargeFrontFaceImageAsync(id, cancel);
+    return stream is null ? Results.NotFound() : Results.Stream(stream, "image/jpeg");
+});
+
+app.MapGet("/api/images/wishlist/{id:int}/front/small", async (
+    int id,
+    ICollectionTrackingService svc,
+    CancellationToken cancel) =>
+{
+    var stream = await svc.GetSmallFrontFaceImageAsync(id, cancel);
+    return stream is null ? Results.NotFound() : Results.Stream(stream, "image/jpeg");
+});
+
+app.MapGet("/api/images/wishlist/{id:int}/back/large", async (
+    int id,
+    ICollectionTrackingService svc,
+    CancellationToken cancel) =>
+{
+    var stream = await svc.GetLargeBackFaceImageAsync(id, cancel);
+    return stream is null ? Results.NotFound() : Results.Stream(stream, "image/jpeg");
+});
+
+app.MapGet("/api/images/wishlist/{id:int}/back/small", async (
+    int id,
+    ICollectionTrackingService svc,
+    CancellationToken cancel) =>
+{
+    var stream = await svc.GetSmallBackFaceImageAsync(id, cancel);
+    return stream is null ? Results.NotFound() : Results.Stream(stream, "image/jpeg");
+});
+
 // ── Scryfall identifiers ──────────────────────────────────────────────────────
 
 app.MapGet("/api/identifiers/isEmpty", async (

--- a/src/MtgCollectionTracker/App.axaml.cs
+++ b/src/MtgCollectionTracker/App.axaml.cs
@@ -87,6 +87,9 @@ public partial class App : Application
     private static void OnUiThreadUnhandledException(object sender, DispatcherUnhandledExceptionEventArgs e)
     {
         e.Handled = true;
+        if (IsIgnorableUnhandledException(e.Exception))
+            return;
+
         ShowExceptionDialog(e.Exception);
     }
 
@@ -94,6 +97,9 @@ public partial class App : Application
     {
         e.SetObserved();
         var ex = e.Exception.InnerException ?? e.Exception;
+        if (IsIgnorableUnhandledException(ex))
+            return;
+
         Dispatcher.UIThread.Post(() => ShowExceptionDialog(ex));
     }
 
@@ -115,5 +121,20 @@ public partial class App : Application
         var dialogVm = new DialogViewModel();
         dialogVm.WithContent("An error occurred", errorVm);
         WeakReferenceMessenger.Default.Send(new OpenDialogMessage { ViewModel = dialogVm });
+    }
+
+    private static bool IsIgnorableUnhandledException(Exception ex)
+    {
+        for (Exception? current = ex; current != null; current = current.InnerException)
+        {
+            if (current.GetType().FullName == "Tmds.DBus.Protocol.DBusException"
+                && current.Message.Contains("org.freedesktop.DBus.Error.ServiceUnknown", StringComparison.Ordinal)
+                && current.Message.Contains("The name is not activatable", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/MtgCollectionTracker/Services/Stubs/StubCollectionTrackingService.cs
+++ b/src/MtgCollectionTracker/Services/Stubs/StubCollectionTrackingService.cs
@@ -226,6 +226,26 @@ public class StubCollectionTrackingService : ICollectionTrackingService
         throw new System.NotImplementedException();
     }
 
+    public ValueTask<Stream?> GetLargeFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public ValueTask<Stream?> GetLargeBackFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public ValueTask<Stream?> GetSmallFrontFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public ValueTask<Stream?> GetSmallBackFaceImageAsync(int wishlistItemId, CancellationToken cancel)
+    {
+        throw new System.NotImplementedException();
+    }
+
     public ValueTask<IReadOnlyList<WishlistItemModel>> UpdateWishlistMetadataAsync(ICollection<int> ids, IScryfallApiClient scryfallApiClient, UpdateCardMetadataProgressCallback? callback, CancellationToken cancel)
     {
         throw new System.NotImplementedException();

--- a/src/MtgCollectionTracker/ViewModels/CardSkuItemViewModel.cs
+++ b/src/MtgCollectionTracker/ViewModels/CardSkuItemViewModel.cs
@@ -290,6 +290,8 @@ public partial class CardSkuItemViewModel : ViewModelBase, ICardSkuItem, ISendab
     public bool HasLatestPrice => OriginalEdition != "PROXY" && LatestPriceValue != null;
 
     int ISendableCardItem.Quantity => CardListPrinter.IsProxyEdition(this.OriginalEdition ?? string.Empty) ? this.ProxyQty : this.RealQty;
+    int? ISendableCardItem.SourceContainerId => this.ContainerId;
+    int? ISendableCardItem.SourceDeckId => this.DeckId;
 
     partial void OnCardImageChanged(Task<Bitmap?> value)
     {

--- a/src/MtgCollectionTracker/ViewModels/CardVisualViewModel.cs
+++ b/src/MtgCollectionTracker/ViewModels/CardVisualViewModel.cs
@@ -234,6 +234,10 @@ public partial class CardVisualViewModel : ViewModelBase, ICardSkuItem, ISendabl
 
     public bool HasLatestPrice => !IsProxy && LatestPriceValue != null;
 
+    public int? SourceContainerId { get; set; }
+
+    public int? SourceDeckId { get; set; }
+
     public CardVisualViewModel ApplyQuantities()
     {
         if (IsProxy)

--- a/src/MtgCollectionTracker/ViewModels/DeckDetailsViewModel.cs
+++ b/src/MtgCollectionTracker/ViewModels/DeckDetailsViewModel.cs
@@ -245,6 +245,7 @@ public partial class DeckDetailsViewModel : DialogContentViewModel, IMultiModeCa
                 {
                     IsGrouped = true,
                     Id = card.SkuId,
+                    SourceDeckId = deck.Id,
                     ScryfallId = card.ScryfallId,
                     IsDoubleFaced = card.IsDoubleFaced,
                     Quantity = grp.Count(),
@@ -273,6 +274,7 @@ public partial class DeckDetailsViewModel : DialogContentViewModel, IMultiModeCa
                 {
                     IsGrouped = true,
                     Id = card.SkuId,
+                    SourceDeckId = deck.Id,
                     ScryfallId = card.ScryfallId,
                     IsDoubleFaced = card.IsDoubleFaced,
                     Quantity = grp.Count(),

--- a/src/MtgCollectionTracker/ViewModels/SendCardsToContainerOrDeckViewModel.cs
+++ b/src/MtgCollectionTracker/ViewModels/SendCardsToContainerOrDeckViewModel.cs
@@ -1,6 +1,7 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using MtgCollectionTracker.Core.Model;
 using MtgCollectionTracker.Core.Services;
 using MtgCollectionTracker.Services;
 using MtgCollectionTracker.Services.Contracts;
@@ -22,9 +23,42 @@ public interface ISendableCardItem
 
     int Quantity { get; }
 
+    int? SourceContainerId { get; }
+
+    int? SourceDeckId { get; }
+
     string CardName { get; }
 
     string Edition { get; }
+}
+
+public partial class SendableCardTransferItemViewModel : ObservableObject
+{
+    public required Guid Id { get; init; }
+
+    public required int AvailableQuantity { get; init; }
+
+    public int? SourceContainerId { get; init; }
+
+    public int? SourceDeckId { get; init; }
+
+    [ObservableProperty]
+    private string _cardName = string.Empty;
+
+    [ObservableProperty]
+    private string _edition = string.Empty;
+
+    [ObservableProperty]
+    private int _quantityToSend;
+
+    partial void OnQuantityToSendChanged(int value)
+    {
+        var clamped = Math.Clamp(value, 1, this.AvailableQuantity);
+        if (clamped != value)
+        {
+            this.QuantityToSend = clamped;
+        }
+    }
 }
 
 public partial class SendCardsToContainerOrDeckViewModel : DialogContentViewModel
@@ -35,8 +69,6 @@ public partial class SendCardsToContainerOrDeckViewModel : DialogContentViewMode
 
     readonly Func<ContainerViewModel> _container;
     readonly Func<DeckViewModel> _deck;
-
-    record MockSendableCard(Guid Id, int Quantity, string CardName, string Edition) : ISendableCardItem;
 
     public SendCardsToContainerOrDeckViewModel(IMessenger messenger,
                                                Func<ContainerViewModel> container,
@@ -66,15 +98,15 @@ public partial class SendCardsToContainerOrDeckViewModel : DialogContentViewMode
             new ContainerViewModel().WithData(new() { Id = 3, Name = "Shoe Box" })
         ];
         this.Cards = [
-            new MockSendableCard(Guid.NewGuid(), 1, "Black Lotus", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Mox Jet", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Mox Ruby", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Mox Emerald", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Mox Pearl", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Mox Sapphire", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Ancestral Recall", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Time Walk", "LEB"),
-            new MockSendableCard(Guid.NewGuid(), 1, "Timetwister", "LEB")
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Black Lotus", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Mox Jet", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Mox Ruby", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Mox Emerald", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Mox Pearl", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Mox Sapphire", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Ancestral Recall", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Time Walk", Edition = "LEB" },
+            new SendableCardTransferItemViewModel { Id = Guid.NewGuid(), AvailableQuantity = 1, QuantityToSend = 1, CardName = "Timetwister", Edition = "LEB" }
         ];
         this.AvailableDecks = [
             new DeckViewModel().WithData(new() { Id = 1, Format = "Vintage", Name = "[Vintage] My Vintage Deck", DeckName = "My Vintage Deck"}),
@@ -126,14 +158,23 @@ public partial class SendCardsToContainerOrDeckViewModel : DialogContentViewMode
 
     public IEnumerable<DeckViewModel>? AvailableDecks { get; internal set; }
 
-    public IEnumerable<ISendableCardItem>? Cards { get; internal set; }
+    public IEnumerable<SendableCardTransferItemViewModel>? Cards { get; internal set; }
 
     [MemberNotNullWhen(true, nameof(SelectedContainer), nameof(SelectedDeck), nameof(Cards))]
     private bool CanSendCards() => this.Cards?.Any() == true && (this.SelectedContainer != null || this.SelectedDeck != null || this.UnSetContainer || this.UnSetDeck || this.MarkAsSideboard.HasValue);
 
     public async Task<SendCardsToContainerOrDeckViewModel> WithCardsAsync(IEnumerable<ISendableCardItem> cards)
     {
-        this.Cards = cards;
+        this.Cards = cards.Select(c => new SendableCardTransferItemViewModel
+        {
+            Id = c.Id,
+            AvailableQuantity = c.Quantity,
+            QuantityToSend = c.Quantity,
+            SourceContainerId = c.SourceContainerId,
+            SourceDeckId = c.SourceDeckId,
+            CardName = c.CardName,
+            Edition = c.Edition
+        }).ToList();
         var containersTask = _service.GetContainersAsync(CancellationToken.None).AsTask();
         var decksTask = _service.GetDecksAsync(null, CancellationToken.None).AsTask();
         await Task.WhenAll(containersTask, decksTask);
@@ -180,7 +221,33 @@ public partial class SendCardsToContainerOrDeckViewModel : DialogContentViewMode
             _selectionState.LastContainerId = this.SelectedContainer?.Id;
             _selectionState.LastDeckId = this.SelectedDeck?.DeckId;
 
-            var skuIds = this.Cards.Select(c => c.Id).ToList();
+            var cardsToSend = this.Cards.Where(c => c.QuantityToSend >= 1).ToList();
+            var skuIds = new List<Guid>(cardsToSend.Count);
+            foreach (var card in cardsToSend)
+            {
+                if (card.QuantityToSend < card.AvailableQuantity)
+                {
+                    var splitSku = await _service.SplitCardSkuAsync(new SplitCardSkuInputModel
+                    {
+                        CardSkuId = card.Id,
+                        Quantity = card.QuantityToSend
+                    }, CancellationToken.None);
+                    skuIds.Add(splitSku.Id);
+                    Messenger.Send(new CardSkuSplitMessage
+                    {
+                        SplitSkuId = card.Id,
+                        NewSkuId = splitSku.Id,
+                        Quantity = card.QuantityToSend,
+                        ContainerId = card.SourceContainerId,
+                        DeckId = card.SourceDeckId
+                    });
+                }
+                else
+                {
+                    skuIds.Add(card.Id);
+                }
+            }
+
             var res = await _service.UpdateCardSkuAsync(new()
             {
                 Ids = skuIds,

--- a/src/MtgCollectionTracker/ViewModels/WishlistItemViewModel.cs
+++ b/src/MtgCollectionTracker/ViewModels/WishlistItemViewModel.cs
@@ -17,7 +17,6 @@ namespace MtgCollectionTracker.ViewModels;
 public partial class WishlistItemViewModel : ViewModelBase, ICardSkuItem
 {
     readonly ICollectionTrackingService _service;
-    private CardImageCache? _imageCache;
     int _smallImageLoadVersion;
     int _largeImageLoadVersion;
 
@@ -69,9 +68,9 @@ public partial class WishlistItemViewModel : ViewModelBase, ICardSkuItem
 
     private async Task<Bitmap?> GetSmallFrontFaceImageAsync()
     {
-        if (this.ScryfallId != null && _imageCache != null)
+        if (this.Id > 0)
         {
-            using var stream = await _imageCache.GetSmallFrontFaceImageAsync(this.ScryfallId);
+            using var stream = await _service.GetSmallFrontFaceImageAsync(this.Id, System.Threading.CancellationToken.None);
             if (stream != null)
                 return new Bitmap(stream);
         }
@@ -80,9 +79,9 @@ public partial class WishlistItemViewModel : ViewModelBase, ICardSkuItem
 
     private async Task<Bitmap?> GetSmallBackFaceImageAsync()
     {
-        if (this.ScryfallId != null && _imageCache != null)
+        if (this.Id > 0)
         {
-            using var stream = await _imageCache.GetSmallBackFaceImageAsync(this.ScryfallId);
+            using var stream = await _service.GetSmallBackFaceImageAsync(this.Id, System.Threading.CancellationToken.None);
             if (stream != null)
                 return new Bitmap(stream);
         }
@@ -101,9 +100,9 @@ public partial class WishlistItemViewModel : ViewModelBase, ICardSkuItem
 
     private async Task<Bitmap?> GetLargeFrontFaceImageAsync()
     {
-        if (this.ScryfallId != null && _imageCache != null)
+        if (this.Id > 0)
         {
-            using var stream = await _imageCache.GetLargeFrontFaceImageAsync(this.ScryfallId);
+            using var stream = await _service.GetLargeFrontFaceImageAsync(this.Id, System.Threading.CancellationToken.None);
             if (stream != null)
                 return new Bitmap(stream);
         }
@@ -112,9 +111,9 @@ public partial class WishlistItemViewModel : ViewModelBase, ICardSkuItem
 
     private async Task<Bitmap?> GetLargeBackFaceImageAsync()
     {
-        if (this.ScryfallId != null && _imageCache != null)
+        if (this.Id > 0)
         {
-            using var stream = await _imageCache.GetLargeBackFaceImageAsync(this.ScryfallId);
+            using var stream = await _service.GetLargeBackFaceImageAsync(this.Id, System.Threading.CancellationToken.None);
             if (stream != null)
                 return new Bitmap(stream);
         }
@@ -333,12 +332,6 @@ public partial class WishlistItemViewModel : ViewModelBase, ICardSkuItem
         this.Tags = string.Join(Environment.NewLine, this.TagList);
         this.TagsText = $"{this.TagList.Length} tag(s)";
         this.SwitchToFront();
-        return this;
-    }
-
-    public WishlistItemViewModel WithImageCache(CardImageCache imageCache)
-    {
-        _imageCache = imageCache;
         return this;
     }
 

--- a/src/MtgCollectionTracker/ViewModels/WishlistViewModel.cs
+++ b/src/MtgCollectionTracker/ViewModels/WishlistViewModel.cs
@@ -20,7 +20,6 @@ public partial class WishlistViewModel : RecipientViewModelBase, IViewModelWithB
 {
     readonly ICollectionTrackingService _service;
     readonly IScryfallApiClient? _scryfallApiClient;
-    private readonly CardImageCache? _imageCache;
 
     readonly Func<DialogViewModel> _dialog;
     readonly Func<EditWishlistItemViewModel> _editWishlistItem;
@@ -47,7 +46,6 @@ public partial class WishlistViewModel : RecipientViewModelBase, IViewModelWithB
     }
 
     public WishlistViewModel(ICollectionTrackingService service,
-        CardImageCache imageCache,
         Func<DialogViewModel> dialog,
         Func<EditWishlistItemViewModel> editWishlistItem,
         Func<AddCardsToWishlistViewModel> addCardsToWishlist,
@@ -59,7 +57,6 @@ public partial class WishlistViewModel : RecipientViewModelBase, IViewModelWithB
     {
         _service = service;
         _scryfallApiClient = scryfallApiClient;
-        _imageCache = imageCache;
         _dialog = dialog;
         _editWishlistItem = editWishlistItem;
         _addCardsToWishlist = addCardsToWishlist;
@@ -122,7 +119,7 @@ public partial class WishlistViewModel : RecipientViewModelBase, IViewModelWithB
             var items = await _service.GetWishlistItemsAsync(filter, CancellationToken.None);
             foreach (var item in items)
             {
-                this.Cards.Add(_wishlistItem().WithImageCache(_imageCache!).WithData(item));
+                this.Cards.Add(_wishlistItem().WithData(item));
             }
             await this.ApplySummaryAsync();
         }

--- a/src/MtgCollectionTracker/Views/EditCardSkuView.axaml
+++ b/src/MtgCollectionTracker/Views/EditCardSkuView.axaml
@@ -11,99 +11,106 @@
          to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
 		<vm:EditCardSkuViewModel />
 	</Design.DataContext>
-	<DockPanel>
-		<StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="6">
+	<!--
+		MaxHeight caps the measurement height so the ScrollViewer receives a finite constraint even
+		when DialogHostAvalonia measures popup content with infinite height. That keeps the action
+		row visible on short displays while allowing the form body to scroll.
+	-->
+	<Grid x:Name="RootGrid" RowDefinitions="*,Auto" RowSpacing="8" MaxHeight="560">
+		<ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+			<StackPanel Spacing="6">
+				<TextBlock>Tick the following fields to apply edits for</TextBlock>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *, 90">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyCardName}">
+						<TextBlock VerticalAlignment="Center">Card Name (must have both names separated by // for adventure and double-faced cards)</TextBlock>
+					</CheckBox>
+					<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyCardName}" Text="{Binding CardName}" />
+					<Button Command="{Binding CheckNameCommand}" Grid.Row="1" Grid.Column="2" Width="90" VerticalAlignment="Center" HorizontalAlignment="Center">Check/Fix</Button>
+				</Grid>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyQuantity}">
+						<TextBlock VerticalAlignment="Center">Quantity</TextBlock>
+					</CheckBox>
+					<NumericUpDown Grid.Row="1" Grid.ColumnSpan="2" FormatString="0" IsEnabled="{Binding ApplyQuantity}" Value="{Binding Quantity}" />
+				</Grid>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyEdition}">
+						<TextBlock VerticalAlignment="Center">Edition (use "PROXY" to indicate proxies)</TextBlock>
+					</CheckBox>
+					<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyEdition}" Text="{Binding Edition}" />
+				</Grid>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyLanguage}">
+						<TextBlock VerticalAlignment="Center">Language</TextBlock>
+					</CheckBox>
+					<ComboBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyLanguage}" MinWidth="200" ItemsSource="{Binding Languages}" SelectedItem="{Binding Language}">
+						<ComboBox.ItemTemplate>
+							<DataTemplate x:DataType="vm:LanguageViewModel">
+								<TextBlock Text="{Binding Name}" />
+							</DataTemplate>
+						</ComboBox.ItemTemplate>
+					</ComboBox>
+				</Grid>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyDeck}">
+						<TextBlock VerticalAlignment="Center">Deck</TextBlock>
+					</CheckBox>
+					<ComboBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyDeck}" MinWidth="200" ItemsSource="{Binding AvailableDecks}" SelectedItem="{Binding Deck}">
+						<ComboBox.ItemTemplate>
+							<DataTemplate x:DataType="vm:DeckViewModel">
+								<TextBlock Text="{Binding Name}" />
+							</DataTemplate>
+						</ComboBox.ItemTemplate>
+					</ComboBox>
+				</Grid>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyContainer}">
+						<TextBlock VerticalAlignment="Center">Container</TextBlock>
+					</CheckBox>
+					<ComboBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyContainer}" MinWidth="200" ItemsSource="{Binding AvailableContainers}" SelectedItem="{Binding Container}">
+						<ComboBox.ItemTemplate>
+							<DataTemplate x:DataType="vm:ContainerViewModel">
+								<TextBlock Text="{Binding Name}" />
+							</DataTemplate>
+						</ComboBox.ItemTemplate>
+					</ComboBox>
+				</Grid>
+				<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyCollector}">
+						<TextBlock VerticalAlignment="Center">Collector # (set to resolve card image for a specific variant)</TextBlock>
+					</CheckBox>
+					<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyCollector}" Text="{Binding CollectorNumber}" />
+				</Grid>
+				<Grid RowDefinitions="Auto, 60" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyComments}">
+						<TextBlock VerticalAlignment="Center">Comments</TextBlock>
+					</CheckBox>
+					<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyComments}" Text="{Binding Comments}" />
+				</Grid>
+				<Grid RowDefinitions="Auto, 60" ColumnDefinitions="30, *">
+					<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyTags}">
+						<TextBlock VerticalAlignment="Center">Tags</TextBlock>
+					</CheckBox>
+					<ListBox IsEnabled="{Binding ApplyTags}" Height="40" Grid.Row="1" Grid.ColumnSpan="2" SelectionMode="Multiple, Toggle" ItemsSource="{Binding AllTags}" SelectedItems="{Binding Tags}">
+						<ListBox.ItemsPanel>
+							<ItemsPanelTemplate>
+								<StackPanel Orientation="Horizontal" />
+							</ItemsPanelTemplate>
+						</ListBox.ItemsPanel>
+					</ListBox>
+				</Grid>
+				<WrapPanel Orientation="Horizontal" ItemSpacing="6" LineSpacing="6">
+					<CheckBox IsThreeState="True" IsChecked="{Binding IsLand}">Is Land?</CheckBox>
+					<CheckBox IsThreeState="True" IsChecked="{Binding IsFoil}">Is Foil?</CheckBox>
+					<CheckBox IsThreeState="True" IsChecked="{Binding IsSideboard}">Is Sideboard?</CheckBox>
+					<CheckBox IsThreeState="True" IsChecked="{Binding UnsetDeck}">Un-set Deck?</CheckBox>
+					<CheckBox IsThreeState="True" IsChecked="{Binding UnsetContainer}">Un-set Container?</CheckBox>
+				</WrapPanel>
+			</StackPanel>
+		</ScrollViewer>
+		<WrapPanel Grid.Row="1" HorizontalAlignment="Right" ItemSpacing="6" LineSpacing="6">
 			<Button Command="{Binding SaveCommand}">Apply</Button>
 			<Button Command="{Binding CancelCommand}">Cancel</Button>
-		</StackPanel>
-		<StackPanel Spacing="6">
-			<TextBlock>Tick the following fields to apply edits for</TextBlock>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *, 90">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyCardName}">
-					<TextBlock VerticalAlignment="Center">Card Name (must have both names separated by // for adventure and double-faced cards)</TextBlock>
-				</CheckBox>
-				<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyCardName}" Text="{Binding CardName}" />
-				<Button Command="{Binding CheckNameCommand}" Grid.Row="1" Grid.Column="2" Width="90" VerticalAlignment="Center" HorizontalAlignment="Center">Check/Fix</Button>
-			</Grid>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyQuantity}">
-					<TextBlock VerticalAlignment="Center">Quantity</TextBlock>
-				</CheckBox>
-				<NumericUpDown Grid.Row="1" Grid.ColumnSpan="2" FormatString="0" IsEnabled="{Binding ApplyQuantity}" Value="{Binding Quantity}" />
-			</Grid>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyEdition}">
-					<TextBlock VerticalAlignment="Center">Edition (use "PROXY" to indicate proxies)</TextBlock>
-				</CheckBox>
-				<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyEdition}" Text="{Binding Edition}" />
-			</Grid>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyLanguage}">
-					<TextBlock VerticalAlignment="Center">Language</TextBlock>
-				</CheckBox>
-				<ComboBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyLanguage}" MinWidth="200" ItemsSource="{Binding Languages}" SelectedItem="{Binding Language}">
-					<ComboBox.ItemTemplate>
-						<DataTemplate x:DataType="vm:LanguageViewModel">
-							<TextBlock Text="{Binding Name}" />
-						</DataTemplate>
-					</ComboBox.ItemTemplate>
-				</ComboBox>
-			</Grid>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyDeck}">
-					<TextBlock VerticalAlignment="Center">Deck</TextBlock>
-				</CheckBox>
-				<ComboBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyDeck}" MinWidth="200" ItemsSource="{Binding AvailableDecks}" SelectedItem="{Binding Deck}">
-					<ComboBox.ItemTemplate>
-						<DataTemplate x:DataType="vm:DeckViewModel">
-							<TextBlock Text="{Binding Name}" />
-						</DataTemplate>
-					</ComboBox.ItemTemplate>
-				</ComboBox>
-			</Grid>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyContainer}">
-					<TextBlock VerticalAlignment="Center">Container</TextBlock>
-				</CheckBox>
-				<ComboBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyContainer}" MinWidth="200" ItemsSource="{Binding AvailableContainers}" SelectedItem="{Binding Container}">
-					<ComboBox.ItemTemplate>
-						<DataTemplate x:DataType="vm:ContainerViewModel">
-							<TextBlock Text="{Binding Name}" />
-						</DataTemplate>
-					</ComboBox.ItemTemplate>
-				</ComboBox>
-			</Grid>
-			<Grid RowDefinitions="Auto, Auto" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyCollector}">
-					<TextBlock VerticalAlignment="Center">Collector # (set to resolve card image for a specific variant)</TextBlock>
-				</CheckBox>
-				<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyCollector}" Text="{Binding CollectorNumber}" />
-			</Grid>
-			<Grid RowDefinitions="Auto, 60" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyComments}">
-					<TextBlock VerticalAlignment="Center">Comments</TextBlock>
-				</CheckBox>
-				<TextBox Grid.Row="1" Grid.ColumnSpan="2" IsEnabled="{Binding ApplyComments}" Text="{Binding Comments}" />
-			</Grid>
-			<Grid RowDefinitions="Auto, 60" ColumnDefinitions="30, *">
-				<CheckBox Grid.Row="0" Grid.ColumnSpan="2" IsChecked="{Binding ApplyTags}">
-					<TextBlock VerticalAlignment="Center">Tags</TextBlock>
-				</CheckBox>
-				<ListBox IsEnabled="{Binding ApplyTags}" Height="40" Grid.Row="1" Grid.ColumnSpan="2" SelectionMode="Multiple, Toggle" ItemsSource="{Binding AllTags}" SelectedItems="{Binding Tags}">
-					<ListBox.ItemsPanel>
-						<ItemsPanelTemplate>
-							<StackPanel Orientation="Horizontal" />
-						</ItemsPanelTemplate>
-					</ListBox.ItemsPanel>
-				</ListBox>
-			</Grid>
-			<StackPanel Orientation="Horizontal" Spacing="6">
-				<CheckBox IsThreeState="True" IsChecked="{Binding IsLand}">Is Land?</CheckBox>
-				<CheckBox IsThreeState="True" IsChecked="{Binding IsFoil}">Is Foil?</CheckBox>
-				<CheckBox IsThreeState="True" IsChecked="{Binding IsSideboard}">Is Sideboard?</CheckBox>
-				<CheckBox IsThreeState="True" IsChecked="{Binding UnsetDeck}">Un-set Deck?</CheckBox>
-				<CheckBox IsThreeState="True" IsChecked="{Binding UnsetContainer}">Un-set Container?</CheckBox>
-			</StackPanel>
-		</StackPanel>
-	</DockPanel>
+		</WrapPanel>
+	</Grid>
 </UserControl>

--- a/src/MtgCollectionTracker/Views/EditCardSkuView.axaml.cs
+++ b/src/MtgCollectionTracker/Views/EditCardSkuView.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 
 namespace MtgCollectionTracker.Views;
@@ -7,5 +8,19 @@ public partial class EditCardSkuView : UserControl
     public EditCardSkuView()
     {
         InitializeComponent();
+    }
+
+    /// <summary>
+    /// Keeps <see cref="RootGrid"/>'s MaxHeight equal to the UserControl's arranged height so the
+    /// scrollable form body receives a finite constraint and the action row remains reachable on
+    /// shorter displays.
+    /// </summary>
+    protected override void OnSizeChanged(SizeChangedEventArgs e)
+    {
+        base.OnSizeChanged(e);
+        if (e.NewSize.Height > 0 && !double.IsInfinity(e.NewSize.Height))
+        {
+            RootGrid.MaxHeight = e.NewSize.Height;
+        }
     }
 }

--- a/src/MtgCollectionTracker/Views/SendCardsToContainerOrDeckView.axaml
+++ b/src/MtgCollectionTracker/Views/SendCardsToContainerOrDeckView.axaml
@@ -50,13 +50,24 @@
 						  CanUserResizeColumns="True"
 						  CanUserSortColumns="False"
 						  GridLinesVisibility="All"
-						  IsReadOnly="True"
 						  BorderThickness="1"
 						  MinHeight="300"
 						  Margin="6"
 						  BorderBrush="Gray">
 					<DataGrid.Columns>
-						<DataGridTextColumn Header="Qty" Binding="{Binding Quantity}"/>
+						<DataGridTextColumn Header="Available" Binding="{Binding AvailableQuantity}"/>
+						<DataGridTemplateColumn Header="Qty to Send" Width="140">
+							<DataGridTemplateColumn.CellTemplate>
+								<DataTemplate x:DataType="vm:SendableCardTransferItemViewModel">
+									<NumericUpDown Value="{Binding QuantityToSend}"
+												   Minimum="1"
+												   Maximum="{Binding AvailableQuantity}"
+												   FormatString="0"
+												   BorderThickness="0"
+												   Padding="4,0" />
+								</DataTemplate>
+							</DataGridTemplateColumn.CellTemplate>
+						</DataGridTemplateColumn>
 						<DataGridTextColumn Header="Card Name" Binding="{Binding CardName}"/>
 						<DataGridTextColumn Header="Edition" Binding="{Binding Edition}"/>
 					</DataGrid.Columns>

--- a/tests/MtgCollectionTracker.Tests/AppUnhandledExceptionTests.cs
+++ b/tests/MtgCollectionTracker.Tests/AppUnhandledExceptionTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Reflection;
+
+namespace MtgCollectionTracker.Tests
+{
+    public class AppUnhandledExceptionTests
+    {
+        [Fact]
+        public void IsIgnorableUnhandledException_ReturnsTrue_ForKnownDbusServiceUnknownError()
+        {
+            var exception = new Tmds.DBus.Protocol.DBusException("org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable");
+
+            Assert.True(IsIgnorable(exception));
+        }
+
+        [Fact]
+        public void IsIgnorableUnhandledException_ReturnsFalse_ForOtherExceptions()
+        {
+            Assert.False(IsIgnorable(new InvalidOperationException("boom")));
+        }
+
+        private static bool IsIgnorable(Exception exception)
+        {
+            var method = typeof(MtgCollectionTracker.App).GetMethod("IsIgnorableUnhandledException", BindingFlags.Static | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("Unable to locate App.IsIgnorableUnhandledException for test.");
+            return (bool)(method.Invoke(null, [exception]) ?? throw new InvalidOperationException("Expected a boolean result."));
+        }
+    }
+}
+
+namespace Tmds.DBus.Protocol
+{
+    internal sealed class DBusException(string message) : Exception(message);
+}

--- a/tests/MtgCollectionTracker.Tests/SendCardsToContainerOrDeckViewModelTests.cs
+++ b/tests/MtgCollectionTracker.Tests/SendCardsToContainerOrDeckViewModelTests.cs
@@ -13,18 +13,22 @@ namespace MtgCollectionTracker.Tests;
 /// </summary>
 public class SendCardsToContainerOrDeckViewModelTests
 {
-    private static SendCardsToContainerOrDeckViewModel CreateViewModel()
+    private static (SendCardsToContainerOrDeckViewModel ViewModel, Mock<ICollectionTrackingService> Service, WeakReferenceMessenger Messenger) CreateViewModel()
     {
         var messenger = new WeakReferenceMessenger();
         var mockService = new Mock<ICollectionTrackingService>();
         var mockClient = new Mock<ScryfallApi.Client.IScryfallApiClient>();
-        return new SendCardsToContainerOrDeckViewModel(
+        mockService.Setup(s => s.GetContainersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        mockService.Setup(s => s.GetDecksAsync(It.IsAny<DeckFilterModel?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+        return (new SendCardsToContainerOrDeckViewModel(
             messenger,
             () => new ContainerViewModel(),
             () => new DeckViewModel(),
             new SendCardsToContainerOrDeckSelectionState(),
             mockService.Object,
-            mockClient.Object);
+            mockClient.Object), mockService, messenger);
     }
 
     private static DeckViewModel MakeDeck(int id = 1, string deckName = "Test Deck") =>
@@ -36,7 +40,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void IsUnSetDeckEnabled_IsTrue_WhenNoDeckSelected()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
 
         Assert.True(vm.IsUnSetDeckEnabled);
     }
@@ -44,7 +48,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void IsUnSetContainerEnabled_IsTrue_WhenNoContainerSelected()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
 
         Assert.True(vm.IsUnSetContainerEnabled);
     }
@@ -52,7 +56,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void IsUnSetDeckEnabled_IsFalse_WhenDeckIsSelected()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
 
         vm.SelectedDeck = MakeDeck();
 
@@ -62,7 +66,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void IsUnSetDeckEnabled_IsTrue_WhenDeckSelectionCleared()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.SelectedDeck = MakeDeck();
 
         vm.SelectedDeck = null;
@@ -73,7 +77,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void IsUnSetContainerEnabled_IsFalse_WhenContainerIsSelected()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
 
         vm.SelectedContainer = MakeContainer();
 
@@ -83,7 +87,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void IsUnSetContainerEnabled_IsTrue_WhenContainerSelectionCleared()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.SelectedContainer = MakeContainer();
 
         vm.SelectedContainer = null;
@@ -94,7 +98,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void SelectingDeck_ClearsUnSetDeck_WhenItWasChecked()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.UnSetDeck = true;
 
         vm.SelectedDeck = MakeDeck();
@@ -105,7 +109,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void SelectingDeck_DoesNotAffectUnSetContainer()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.UnSetContainer = true;
 
         vm.SelectedDeck = MakeDeck();
@@ -116,7 +120,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void SelectingContainer_ClearsUnSetContainer_WhenItWasChecked()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.UnSetContainer = true;
 
         vm.SelectedContainer = MakeContainer();
@@ -127,7 +131,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void SelectingContainer_DoesNotAffectUnSetDeck()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.UnSetDeck = true;
 
         vm.SelectedContainer = MakeContainer();
@@ -138,7 +142,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void ClearingDeckSelection_DoesNotRestoreUnSetDeck()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.UnSetDeck = true;
         vm.SelectedDeck = MakeDeck(); // clears UnSetDeck
 
@@ -151,7 +155,7 @@ public class SendCardsToContainerOrDeckViewModelTests
     [Fact]
     public void ClearingContainerSelection_DoesNotRestoreUnSetContainer()
     {
-        var vm = CreateViewModel();
+        var (vm, _, _) = CreateViewModel();
         vm.UnSetContainer = true;
         vm.SelectedContainer = MakeContainer(); // clears UnSetContainer
 
@@ -160,4 +164,49 @@ public class SendCardsToContainerOrDeckViewModelTests
         // UnSetContainer remains false after clearing selection (user must re-check manually)
         Assert.False(vm.UnSetContainer);
     }
+
+    [Fact]
+    public async Task SendCards_SplitsPartialQuantity_BeforeTransfer()
+    {
+        var (vm, service, messenger) = CreateViewModel();
+        var sourceSkuId = Guid.NewGuid();
+        var splitSkuId = Guid.NewGuid();
+
+        await vm.WithCardsAsync([
+            new TestSendableCard(sourceSkuId, 4, 12, null, "Black Lotus", "LEA")
+        ]);
+
+        var card = vm.Cards!.Single();
+        card.QuantityToSend = 2;
+        vm.SelectedContainer = MakeContainer(7, "Trade Binder");
+
+        service.Setup(s => s.SplitCardSkuAsync(
+                It.Is<SplitCardSkuInputModel>(m => m.CardSkuId == sourceSkuId && m.Quantity == 2),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CardSkuModel
+            {
+                Id = splitSkuId,
+                CardName = "Black Lotus",
+                Edition = "LEA",
+                Quantity = 2,
+                Tags = []
+            });
+        service.Setup(s => s.UpdateCardSkuAsync(
+                It.Is<UpdateCardSkuInputModel>(m => m.Ids.SequenceEqual(new[] { splitSkuId }) && m.ContainerId == 7),
+                It.IsAny<ScryfallApi.Client.IScryfallApiClient?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateCardSkuResult(1, [new SkuUpdateInfo(splitSkuId, 2, 2, null, null, 12, 7)]));
+
+        await vm.SendCardsCommand.ExecuteAsync(null);
+
+        service.VerifyAll();
+    }
+
+    private sealed record TestSendableCard(
+        Guid Id,
+        int Quantity,
+        int? SourceContainerId,
+        int? SourceDeckId,
+        string CardName,
+        string Edition) : ISendableCardItem;
 }

--- a/tests/MtgCollectionTracker.Tests/WishlistItemViewModelTests.cs
+++ b/tests/MtgCollectionTracker.Tests/WishlistItemViewModelTests.cs
@@ -1,0 +1,39 @@
+using Moq;
+using MtgCollectionTracker.Core.Model;
+using MtgCollectionTracker.Core.Services;
+using MtgCollectionTracker.ViewModels;
+using System.IO;
+using System.Threading;
+
+namespace MtgCollectionTracker.Tests;
+
+public class WishlistItemViewModelTests
+{
+    [Fact]
+    public async Task WithData_LoadsWishlistImagesThroughService()
+    {
+        var service = new Mock<ICollectionTrackingService>();
+        service.Setup(s => s.GetSmallFrontFaceImageAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream?)null);
+        service.Setup(s => s.GetLargeFrontFaceImageAsync(42, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream?)null);
+
+        var vm = new WishlistItemViewModel(service.Object);
+
+        vm.WithData(new WishlistItemModel
+        {
+            Id = 42,
+            CardName = "Black Lotus",
+            Edition = "LEA",
+            Quantity = 1,
+            Tags = [],
+            Offers = []
+        });
+
+        await vm.CardImage;
+        await vm.CardImageLarge;
+
+        service.Verify(s => s.GetSmallFrontFaceImageAsync(42, It.IsAny<CancellationToken>()), Times.Once);
+        service.Verify(s => s.GetLargeFrontFaceImageAsync(42, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
This pull request introduces support for fetching and serving images of wishlist items by their ID, adds related API endpoints, and improves the card transfer dialog by tracking the source container and deck for each card. It also refines exception handling for ignorable DBus errors and enhances the transfer dialog's card quantity handling.

**Wishlist Item Image Support**

* Added new API endpoints in the server (`Program.cs`) to fetch large/small, front/back images of wishlist items by their ID. These are exposed at `/api/images/wishlist/{id}/front/large`, `/front/small`, `/back/large`, and `/back/small`. (`[[1]](diffhunk://#diff-88f160e3271687f6c37bc8eca3db2a482cc9407651f517589d667ba2dd42b2a0R640-R677)`, `[[2]](diffhunk://#diff-23eb650c8b0eedfd68d2f9e3f96cfc37f04e9f794c6f72e222820b4c9ae2aa57R1835-R1930)`)
* Updated the OpenAPI JSON (`MtgCollectionTracker.Server.json`) to document the new wishlist image endpoints. (`[src/MtgCollectionTracker.ApiClient/MtgCollectionTracker.Server.jsonR1835-R1930](diffhunk://#diff-23eb650c8b0eedfd68d2f9e3f96cfc37f04e9f794c6f72e222820b4c9ae2aa57R1835-R1930)`)
* Implemented corresponding methods in the API client (`RemoteCollectionTrackingService.cs`) and core service (`CollectionTrackingService.cs`), as well as in the service interface and stub. These methods fetch images for wishlist items by ID. (`[[1]](diffhunk://#diff-75682c3195dd6b3779dbba694eda45102d87bba52132cf3db7a714376773f7b3R426-R437)`, `[[2]](diffhunk://#diff-06895cc955c839b4272356c210952f604b6b50f790029631e07c7c661c31763aR1873-R1881)`, `[[3]](diffhunk://#diff-06895cc955c839b4272356c210952f604b6b50f790029631e07c7c661c31763aR1906-R1929)`, `[[4]](diffhunk://#diff-ae57f8acb15144cd091841b16c1bc88a4564f42748d65f50094a1bc8a0e42ab9R118-R129)`, `[[5]](diffhunk://#diff-a9b195819b7bd248921163545a2ac17d68ad94c59feecafabac586dc90d5331dR229-R248)`)

**Card Transfer Dialog Improvements**

* Extended the `ISendableCardItem` interface and related view models to include `SourceContainerId` and `SourceDeckId`, allowing the transfer dialog to track the origin of each card. (`[[1]](diffhunk://#diff-94def6da2ff4c4c21153ea09b31b53b6368cfd0f8e8796118dce29ab6d872d0dR26-R63)`, `[[2]](diffhunk://#diff-94def6da2ff4c4c21153ea09b31b53b6368cfd0f8e8796118dce29ab6d872d0dL39-L40)`, `[[3]](diffhunk://#diff-e1e2c84c7c6cd9e0366e6c937a412413e8cebb9292ee22bbb7e86f51faea8ad1R293-R294)`, `[[4]](diffhunk://#diff-ffc2b358b8166cdff2c8c41ddcda28a7dcc5f6c48d31221339a89296a37a4a13R237-R240)`, `[[5]](diffhunk://#diff-28cd2ab49dd6904282e2f957da1ea0fca64a731c80638d39e6cd7cb59f179e2cR248)`, `[[6]](diffhunk://#diff-28cd2ab49dd6904282e2f957da1ea0fca64a731c80638d39e6cd7cb59f179e2cR277)`)
* Refactored the transfer dialog to use a new `SendableCardTransferItemViewModel`, which supports quantity clamping and carries over source information. The dialog's mock/test data and card population logic were updated accordingly. (`[[1]](diffhunk://#diff-94def6da2ff4c4c21153ea09b31b53b6368cfd0f8e8796118dce29ab6d872d0dL69-R109)`, `[[2]](diffhunk://#diff-94def6da2ff4c4c21153ea09b31b53b6368cfd0f8e8796118dce29ab6d872d0dL129-R177)`)

**Exception Handling**

* Improved global exception handling to ignore specific DBus exceptions that are considered non-critical, preventing unnecessary error dialogs. (`[[1]](diffhunk://#diff-408423b56a29a6847a31b8e9e6eb3e53d20ebd827cfb90750a3ccc5efbc126e7R90-R102)`, `[[2]](diffhunk://#diff-408423b56a29a6847a31b8e9e6eb3e53d20ebd827cfb90750a3ccc5efbc126e7R125-R139)`)

**Other Minor Improvements**

* Minor code cleanup and using directive fixes. (`[src/MtgCollectionTracker/ViewModels/SendCardsToContainerOrDeckViewModel.csL1-R4](diffhunk://#diff-94def6da2ff4c4c21153ea09b31b53b6368cfd0f8e8796118dce29ab6d872d0dL1-R4)`)

These changes collectively enhance the app's ability to serve and display wishlist item images and improve the user experience when transferring cards between containers and decks.

Fixes #124
Fixes #125
Fixes #126
Fixes #127
Fixes #128